### PR TITLE
PLATUI-39

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -17,7 +17,7 @@ $if(!cucumber.truthy)$
 $endif$
 
 libraryDependencies ++= Seq(
-  "uk.gov.hmrc"                %% "webdriver-factory"       % "0.6.0"   % "test",
+  "uk.gov.hmrc"                %% "webdriver-factory"       % "0.7.0"   % "test",
   "org.scalatest"              %% "scalatest"               % "3.0.7" % "test",
   $if(!cucumber.truthy)$
   "org.pegdown"                %  "pegdown"                 % "1.2.1" % "test",
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
   "junit"                      %  "junit"                   % "4.12"  % "test",
   "com.novocode"               %  "junit-interface"         % "0.11"  % "test",
   $endif$
-  "uk.gov.hmrc"                %% "zap-automation"          % "1.14.0"  % "test",
+  "uk.gov.hmrc"                %% "zap-automation"          % "2.1.0"  % "test",
   "com.typesafe"               %  "config"                  % "1.3.2"
   )
 

--- a/src/main/g8/src/test/resources/features/$if(cucumber.truthy)$Example.feature$endif$
+++ b/src/main/g8/src/test/resources/features/$if(cucumber.truthy)$Example.feature$endif$
@@ -1,3 +1,4 @@
+$if(cucumber.truthy)$
 @Example
 
 Feature: Example Feature file using Cucumber
@@ -7,3 +8,8 @@ Feature: Example Feature file using Cucumber
     Given a user logs in to access payments page
     When the user chooses to pay VAT tax
     Then payment details page is displayed
+$endif$
+
+$if(!cucumber.truthy)$
+# This file is not required for Scalatest. Please delete. Created as a result of incorrect g8 behaviour.
+$endif$


### PR DESCRIPTION
Modified g8 truthy condition to fix failures during Scalatest test suite creation. g8 truthy condition to create folders appears to be working incorrectly.

Bumped the versions of `webdriver-factory` and `zap-automation`