### PR TITLE
PLATUI-389 reverted scala version to 2.11.11 and raised a new ticket …

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -4,7 +4,7 @@ name := "$name$"
 
 version := "0.1.0"
 
-scalaVersion := "2.12.10"
+scalaVersion := "2.11.11"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 

--- a/src/main/g8/run_tests.sh
+++ b/src/main/g8/run_tests.sh
@@ -10,7 +10,7 @@ elif [ "\$BROWSER" = "firefox" ]; then
 fi
 
 $if(cucumber.truthy)$
-sbt -Dbrowser=\$BROWSER -Denvironment=\$ENV \$DRIVER "test-only uk.gov.hmrc.test.ui.cucumber.runner.Runner"
+sbt -Dbrowser=\$BROWSER -Denvironment=\$ENV \$DRIVER "testOnly uk.gov.hmrc.test.ui.cucumber.runner.Runner"
 $else$
 sbt -Dbrowser=\$BROWSER -Denvironment=\$ENV \$DRIVER "testOnly uk.gov.hmrc.test.ui.specs.*"
 $endif$

--- a/src/main/g8/run_zap_tests.sh
+++ b/src/main/g8/run_zap_tests.sh
@@ -14,7 +14,7 @@ fi
 # single ZAP focused journey test is sufficient.
 
 $if(cucumber.truthy)$
-sbt -Dbrowser=\$BROWSER -Denvironment=\$ENV \$DRIVER -Dzap.proxy=true "test-only uk.gov.hmrc.test.ui.cucumber.runner.ZapRunner"
+sbt -Dbrowser=\$BROWSER -Denvironment=\$ENV \$DRIVER -Dzap.proxy=true "testOnly uk.gov.hmrc.test.ui.cucumber.runner.ZapRunner"
 $else$
 # -n ZapTests Runs only the tests tagged as ZapTests.
 sbt -Dbrowser=\$BROWSER -Denvironment=\$ENV \$DRIVER -Dzap.proxy=true "testOnly uk.gov.hmrc.test.ui.specs.* -- -n ZapTests"


### PR DESCRIPTION
…to investigate scala 2.12 + info.cukes 1.2.6 compatibility.  Changed scala task names from test-only to testOnly (which is the only name supported by sbt 1.3.8)