### PR TITLE
Refactored test-in-local-environment.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,7 @@ To successfully run the tests you will need to satisfy the following pre-requisi
 - Install Mongo (see Confluence)
 - Install ZAP (see Confluence)
 
-Copy `test-in-local-environment.sh` to the parent directory of your local copy of the ui-test-template.g8 project. 
- Execute the script without params:
-
+Execute the script without params:
 ```
 ./test-in-local-environment.sh
 ```

--- a/test-in-local-environment.sh
+++ b/test-in-local-environment.sh
@@ -1,75 +1,66 @@
-#!/bin/bash
+#!/bin/bash -e
 
-# Check pre-reqs
-if ! hash docker 2>/dev/null; then
-  echo "'docker' was not found in PATH.  You will need docker installed to execute these tests.  https://docs.docker.com/install/ "
-  exit 1
-fi
+print() {
+  echo
+  echo -----------------------------------------------------------------------------------------------------------------
+  echo $1
+  echo -----------------------------------------------------------------------------------------------------------------
+  echo
+}
 
-if [ -f /usr/local/bin/geckodriver ]; then
-  echo "geckodriver Found"
-else
-  echo "geckodriver NOT FOUND. Please install the geckodriver binary on your local machine."
-  exit 1
-fi
+print "INFO: Running 'sbt clean' command to clean target folder"
+sbt clean
 
-if [ -f /usr/local/bin/chromedriver ]; then
-  echo "chromedriver Found"
-else
-  echo "chromedriver NOT FOUND. Please install the chromedriver binary on your local machine."
-  exit 1
-fi
+print "INFO: Setting TEMPLATE_DIRECTORY as $PWD"
+TEMPLATE_DIRECTORY=$PWD
 
-start_mongo_container() {
-  echo "starting Mongo container"
+print "INFO: Setting SANDBOX directory as $PWD/target/sandbox"
+SANDBOX="$TEMPLATE_DIRECTORY/target/sandbox"
+REPO_NAME="$TEMPLATE_TYPE-ui-test"
+
+print "INFO: Creating folder: $SANDBOX"
+mkdir -p $SANDBOX
+
+check_prerequisites() {
+  if ! hash docker 2>/dev/null; then
+    print "ERROR: 'docker' was not found in PATH.  You will need docker installed to execute these tests.  https://docs.docker.com/install/ "
+    exit 1
+  fi
+
+  if [ -f /usr/local/bin/geckodriver ]; then
+    print "INFO: geckodriver Found"
+  else
+    print "ERROR: geckodriver NOT FOUND. Please install the geckodriver binary on your local machine."
+    exit 1
+  fi
+
+  if [ -f /usr/local/bin/chromedriver ]; then
+    print "INFO: chromedriver Found"
+  else
+    print "ERROR: chromedriver NOT FOUND. Please install the chromedriver binary on your local machine."
+    exit 1
+  fi
+}
+
+setup_local_environment() {
+  print "INFO: Starting Mongo container"
+
   if docker ps | grep "mongo"; then
-    echo "Mongo container is already running"
+    print "INFO: Mongo container is already running"
   else
     docker run --rm -d --name mongo -p 27017:27017 mongo:3.6
-    echo "Mongo container started"
+    print "INFO: Mongo container started"
   fi
 
+  print "INFO: Starting SM profile"
+  sm --start UI_TEST_TEMPLATE --appendArgs '{"PAY_FRONTEND":["-Dplay.http.session.sameSite=Lax"]}' -r
 }
 
-start_browser_container() {
-  echo "Running script to start $1 container"
-  ./run-browser-with-docker.sh "$1"
-
-  if docker ps | grep "$1"; then
-    echo "$1 container started"
-  else
-    echo "$1 container failed to start"
-    exit 1
-  fi
-}
-
-start_zap() {
-
-  case "$OSTYPE" in
-  darwin*) ZAP_INSTALLATION_DIR="/Applications/OWASP ZAP.app/Contents/Java" ;;
-  linux*) ZAP_INSTALLATION_DIR="~/.ZAP" ;;
-  *)
-    echo "unknown OS TYPE: $OSTYPE"
-    exit 1
-    ;;
-  esac
-
-  if [[ ! -d "$ZAP_INSTALLATION_DIR" ]]; then
-    echo "ZAP Directory Not found. Check if ZAP is installed in $ZAP_INSTALLATION_DIR"
-    exit 1
-  fi
-
-  echo "Starting ZAP from $ZAP_INSTALLATION_DIR"
-
-  "$ZAP_INSTALLATION_DIR/zap.sh" &>/dev/null &
-  ZAP_PID=$!
-
-  sleep 5
-
-}
-
-shutdown_zap() {
-  curl http://localhost:11000/JSON/core/action/shutdown/?
+generate_test_repo() {
+  print "Changing to $SANDBOX directory to generate new repository"
+  cd $SANDBOX
+  print "INFO: Using ui-test-template.g8 to generate new test repository with values: $1 $2"
+  g8 file:///$TEMPLATE_DIRECTORY $1 $2
 }
 
 initialize_repo() {
@@ -81,81 +72,98 @@ initialize_repo() {
   git commit -m "initial commit"
 }
 
-# SETUP
-## Services
-start_mongo_container
-sm --start UI_TEST_TEMPLATE --appendArgs '{"PAY_FRONTEND":["-Dplay.http.session.sameSite=Lax"]}' -r
+start_browser_container() {
+  print "INFO: Running script to start $1 container"
+  ./run-browser-with-docker.sh "$1"
 
-# Test 1 - chrome driver, local, scalatest
-g8 file://ui-test-template.g8/ --name=test-1
-(
-  cd test-1 || exit
+  if docker ps | grep "$1"; then
+    print "INFO: $1 container started"
+  else
+    print "INFO: $1 container failed to start"
+    exit 1
+  fi
+}
+
+start_zap() {
+
+  case "$OSTYPE" in
+  darwin*) ZAP_INSTALLATION_DIR="/Applications/OWASP ZAP.app/Contents/Java" ;;
+  linux*) ZAP_INSTALLATION_DIR="~/.ZAP" ;;
+  *)
+    print "ERROR: Unknown OS TYPE: $OSTYPE"
+    exit 1
+    ;;
+  esac
+
+  if [[ ! -d "$ZAP_INSTALLATION_DIR" ]]; then
+    print "ERROR: ZAP Directory Not found. Check if ZAP is installed in $ZAP_INSTALLATION_DIR"
+    exit 1
+  fi
+
+  print "INFO: Starting ZAP from $ZAP_INSTALLATION_DIR"
+  "$ZAP_INSTALLATION_DIR/zap.sh" &>/dev/null &
+  ZAP_PID=$!
+
+  sleep 5
+}
+
+clear_zap_session() {
+  print "INFO: Clearing ZAP session for any subsequent test"
+  curl "http://localhost:11000/JSON/core/action/newSession/?name=&overwrite="
+}
+
+run_scalatest_tests() {
+  generate_test_repo --name=scalatest-repo
+  print "INFO: Test 1 - chrome driver, local, scalatest"
+  cd "$SANDBOX/scalatest-repo"
   initialize_repo
   ./run_tests.sh
-)
-rm -rf test-1
 
-# Test 2 - chrome docker, local, scalatest
-g8 file://ui-test-template.g8/ --name=test-2
-cd test-2 || exit
-initialize_repo
-start_browser_container remote-chrome
-./run_tests.sh local remote-chrome
-cd - || exit
-rm -rf test-2
-docker stop remote-chrome
+  print "INFO: Test 2 - chrome docker, local, scalatest"
+  start_browser_container remote-chrome
+  ./run_tests.sh local remote-chrome
+  docker stop remote-chrome
 
-# Test 3 - chrome docker, local, cucumber
-g8 file://ui-test-template.g8/ --name=test-3 --cucumber=true
-cd test-3 || exit
-initialize_repo
-start_browser_container remote-chrome
-./run_tests.sh local remote-chrome
-cd - || exit
-rm -rf test-3
-docker stop remote-chrome
-
-# Test 4 - firefox docker, local, cucumber
-g8 file://ui-test-template.g8/ --name=test-4 --cucumber=true
-cd test-4 || exit
-initialize_repo
-start_browser_container remote-firefox
-./run_tests.sh local remote-firefox
-cd - || exit
-rm -rf test-4
-docker stop remote-firefox
-
-# Test 5 - firefox driver, local, cucumber
-g8 file://ui-test-template.g8/ --name=test-5 --cucumber=true
-(
-  cd test-5 || exit
-  initialize_repo
-  ./run_tests.sh local firefox
-)
-rm -rf test-5
-
-# Test 6 - zap, chrome driver, local, scalatest
-start_zap
-g8 file://ui-test-template.g8/ --name=test-6
-(
-  cd test-6 || exit
-  initialize_repo
+  print "INFO: Test 3 - zap, chrome driver, local, scalatest"
+  start_zap
   ./run_zap_tests.sh local chrome
-)
-shutdown_zap
-rm -rf test-6
+  clear_zap_session
+}
 
-# Test 7 - zap, firefox driver, local, cucumber
-start_zap
-g8 file://ui-test-template.g8/ --name=test-7 --cucumber=true
-(
-  cd test-7 || exit
+run_cucumber_tests() {
+  generate_test_repo --name=cucumber-repo
+
+  print "INFO: Test 4 - chrome docker, local, cucumber"
+  cd "$SANDBOX/cucumber-repo"
   initialize_repo
-  ./run_zap_tests.sh local firefox
-)
-shutdown_zap
-rm -rf test-7
+  start_browser_container remote-chrome
+  ./run_tests.sh local remote-chrome
+  docker stop remote-chrome
 
-# TEAR DOWN
-sm --stop UI_TEST_TEMPLATE
-docker stop mongo
+  print "INFO: Test 5 - firefox docker, local, cucumber"
+  start_browser_container remote-firefox
+  ./run_tests.sh local remote-firefox
+  docker stop remote-firefox
+
+  print "INFO: Test 6 - firefox driver, local, cucumber"
+  ./run_tests.sh local firefox
+
+  print "INFO: Test 7 - zap, firefox driver, local, cucumber"
+  ./run_zap_tests.sh local firefox
+  clear_zap_session
+}
+
+tear_down() {
+  print "INFO: Stopping SM profile"
+  sm --stop UI_TEST_TEMPLATE
+  print "INFO: Stopping Mongo container"
+  docker stop mongo
+  print "INFO: Shutdown ZAP"
+  curl http://localhost:11000/JSON/core/action/shutdown/?
+}
+
+check_prerequisites
+setup_local_environment
+run_scalatest_tests
+run_cucumber_tests
+tear_down


### PR DESCRIPTION
The script has been updated to:
* run now without having to copied into a different folder
* generate only two repositories - one for cucumber and one for scalatest
* ZAP session is cleared in between tests instead of shutting down. 
